### PR TITLE
 Rewrite check for square brackets in exec form 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,20 @@ This will validate the `Dockerfile` in your current directory.
 
 ### Running from a git clone
 
-If you've cloned this repository, you can run `dockerlint` with:
+If you've cloned this repository, you will need the following prerequisites:
+1. make
+2. [npm](https://www.npmjs.com/)
+3. [coffee](http://coffeescript.org/)
+
+Installing prerequisites on ubuntu:
+
+    sudo apt-get update
+    sudo apt-get install make
+    sudo apt-get install npm
+    sudo ln -s /usr/bin/nodejs /usr/bin/node
+    sudo npm install -g coffee-script
+
+You can run `dockerlint` with:
 
     make deps # runs npm install
     make js && coffee bin/dockerlint.coffee

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -28,3 +28,8 @@ exports.log = (level, msg) ->
     else
       process.stdout.write "#{sty.blue 'DEBUG'}:"
       console.dir msg
+
+# Return true if object is an array
+# From http://stackoverflow.com/a/16608045/4126114
+exports.isArray = (a) -> (!!a) && (a.constructor is Array)
+

--- a/test/checksTest.coffee
+++ b/test/checksTest.coffee
@@ -79,13 +79,23 @@ describe "json_array_even_quotes", ->
 
 describe "json_array_brackets", ->
   for cmd in [ 'CMD', 'ENTRYPOINT', 'RUN', 'VOLUME' ]
-    it "should not act on non-exec form arguments for #{cmd}", ->
-      c.json_array_brackets([ {line: 1, instruction: cmd, arguments: ['"foo"'] }]).should.be.equal 'ok'
+    for arg in [ '"foo"', '"echo [foo]"' ]
+      it "should not act on non-exec form arguments for #{cmd} #{arg}", ->
+        c.json_array_brackets([ {line: 1, instruction: cmd, arguments: [arg] }]).should.be.equal 'ok'
+
+    for arg in [ '["foo"]', ' ["foo"]', '["foo"]  ', ' ["foo"]  ' ]
+      it "should allow spaces around non-exec form arguments for #{cmd} #{arg}", ->
+        c.json_array_brackets([ {line: 1, instruction: cmd, arguments: [arg] }]).should.be.equal 'ok'
+
     for test in [
       {desc: "are multiple closing brackets", test: '[["foo"]'},
       {desc: "are multiple opening brackets", test: '["bar"]]'},
       {desc: "is no opening bracket", test: '"baz"]'},
-      {desc: "is no closing bracket", test: '["quux"'}]
+      {desc: "is no closing bracket", test: '["quux"'},
+      {desc: "are multiple commas", test: '["foo",,]'},
+      {desc: "are nested arrays (1)", test: '["foo",[]]'},
+      {desc: "are nested arrays (2)", test: '["foo",["foo"]]'},
+    ]
       it "should fail if #{test.desc} for #{cmd}", ->
         c.json_array_brackets([ {line: 1, instruction: cmd, arguments: [test.test] }]).should.be.equal 'failed'
 

--- a/test/utilsTest.coffee
+++ b/test/utilsTest.coffee
@@ -22,3 +22,10 @@ describe "notEmpty", ->
 
   it "should return true if string is not empty", ->
     u.notEmpty('Jabba').should.equal true
+
+describe "isArray", ->
+  it "should return true if object is an array", ->
+    u.isArray([]).should.equal true
+
+  it "should return false if object is not an array", ->
+    u.isArray('Jabba').should.equal false


### PR DESCRIPTION
The new implementation simplifies the function by using `JSON.parse`.
It also simplifies the alerts by just saying that the array is invalid, instead of specifying the extra brackets.
Even though this loses detail in terms of what exactly is wrong with the array, it makes the check function more comprehensive in terms of cases covered and simpler to maintain now that it's free of regular expressions.
The added unit tests exemplify this.