### PR TITLE
Switch the node image to the alpine variant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4-slim
+FROM node:4-alpine
 
 MAINTAINER Jasper Lievisse Adriaanse <jasper@redcoolbeans.com>
 


### PR DESCRIPTION
Significantly reduces the size of the end image from 205Mb to 38Mb