### PR TITLE
Add missing dependency to Dockerfile-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:4-alpine
 
 MAINTAINER Jasper Lievisse Adriaanse <jasper@redcoolbeans.com>
 
-RUN npm install -g dockerlint
+RUN npm install -g dockerlint \
+ && npm cache clean
 
 ENTRYPOINT ["dockerlint", "-f", "/Dockerfile"]

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,11 +1,13 @@
-FROM node:4
+FROM node:4-alpine
 
-RUN git clone https://github.com/RedCoolBeans/dockerlint.git
+MAINTAINER Jasper Lievisse Adriaanse <jasper@redcoolbeans.com>
 
-WORKDIR dockerlint
+COPY . /dockerlint
+WORKDIR /dockerlint
 
-RUN npm install -g coffee-script && \
-	make js && \
-	npm install -g
+RUN npm install -g coffee-script \
+ && make js \
+ && npm install -g \
+ && npm cache clean
 
 ENTRYPOINT ["dockerlint", "-f", "/Dockerfile"]


### PR DESCRIPTION
make is used but not present in the node:4 or node:4-alpine images. This
also includes a few minor tweaks inspired by Docker's official best
practices documentation page.

* slight reduction of image size (1MB) via npm cache clear (not in -dev)
* add maintainer to match other Dockerfile
* switch -dev to use alpine variant of node image
* prefer COPY to git clone since we already have the src (also faster)

### Issue details

_Please provide issue details here and how your commit(s) fix it_.

### Steps to reproduce/test case

_Please provide necessary steps and relevant parts of your Dockkerfile
below for reproduction of this issue_

<!--
Please include tests in your pull request, it greatly helps others to
ensure this particular issue won't be re-introduced again.
-->
