### PR TITLE
Fix sudo false positive

### DIFF
--- a/src/checks.coffee
+++ b/src/checks.coffee
@@ -183,7 +183,7 @@ exports.sudo = (rules) ->
   run = this.getAll('RUN', rules)
   for rule in run
     for argument in rule.arguments
-      if argument.match /sudo/
+      if argument.match /(^|.*;)\s*(\/?.*\/)?sudo(\s|$)/
         utils.log 'WARN', "sudo(8) usage found on line #{rule.line} which is discouraged"
         return 'failed'
   return 'ok'

--- a/test/checksTest.coffee
+++ b/test/checksTest.coffee
@@ -126,6 +126,24 @@ describe "sudo", ->
   it "should warn when sudo is used", ->
     c.sudo([ {line: 1, instruction: 'RUN', arguments: ['sudo rm -rf /']} ]).should.be.equal 'failed'
 
+  it "should warn when sudo is used in absolute path form", ->
+    c.sudo([ {line: 1, instruction: 'RUN', arguments: ['/usr/bin/sudo rm -rf /']} ]).should.be.equal 'failed'
+
+  it "should warn when sudo is used with preceding spaces/tabs", ->
+    c.sudo([ {line: 1, instruction: 'RUN', arguments: [' 	  sudo rm -rf /']} ]).should.be.equal 'failed'
+
+  it "should warn when sudo is used after semicolon", ->
+    c.sudo([ {line: 1, instruction: 'RUN', arguments: ['date; sudo rm -rf /']} ]).should.be.equal 'failed'
+
+  it "should warn when sudo is used at the end of line", ->
+    c.sudo([ {line: 1, instruction: 'RUN', arguments: ['date; sudo']} ]).should.be.equal 'failed'
+
+  it "should not warn when sudoer file is being used", ->
+    c.sudo([ {line: 1, instruction: 'RUN', arguments: ['echo "jenkins ALL=(ALL) ALL" >> etc/sudoers']} ]).should.be.equal 'ok'
+
+  it "should not warn when sudo is not a verb in the sentence", ->
+    c.sudo([ {line: 1, instruction: 'RUN', arguments: ['yum list installed | grep sudo']} ]).should.be.equal 'ok'
+
 describe "absolute_workdir", ->
   it "should fail when WORKDIR uses a relative path", ->
     c.absolute_workdir([ {line: 1, instruction: 'WORKDIR', arguments: ['../']} ]).should.be.equal 'failed'


### PR DESCRIPTION
### Issue details

This PR is intended to fix #23 False positive on the use of SUDO

### Steps to reproduce/test case

The test cases have been included in this PR, contains the following scenario in test case:

```
/usr/bin/sudo rm -rf /  # absolute path to sudo binary
 	  sudo rm -rf /  # spaces and tabs before sudo
date; sudo rm -rf /  # semicolon before sudo
date; sudo  # sudo in end of sentence
echo "jenkins ALL=(ALL) ALL" >> etc/sudoers  # false alarm for sudoers file
yum list installed | grep sudo  # false alarm for not using sudo
```