### PR TITLE
Don't apply quotes check on non exec forms

### DIFF
--- a/src/checks.coffee
+++ b/src/checks.coffee
@@ -101,10 +101,6 @@ exports.json_array_format = (rules) ->
             if not arg.trim().match /^\[?(\s+)?\".*\"(\s+)?\]?$/
               utils.log 'ERROR', errmsg
               return 'failed'
-        else
-          if argument.match /\[.*'.*\]/
-            utils.log 'ERROR', errmsg
-            return 'failed'
   return 'ok'
 
 # Ensure the exec form contains a balanced number of double quotes.


### PR DESCRIPTION
The point of that check is to make sure that the exec form doesn't use single quotes.
There is no reason to have an `else` to handle the case where it isn't the exec form and potentially fail then.
Fixes #33