### PR TITLE
Move flags to CMD to allow changing file name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ MAINTAINER Red Cool Beans <maintainer@redcoolbeans.com>
 RUN npm install -g dockerlint \
  && npm cache clean
 
-ENTRYPOINT ["dockerlint", "-f", "/Dockerfile"]
+ENTRYPOINT ["dockerlint"]
+CMD [ "-f", "/Dockerfile"]

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -10,4 +10,5 @@ RUN npm install -g coffee-script \
  && npm install -g \
  && npm cache clean
 
-ENTRYPOINT ["dockerlint", "-f", "/Dockerfile"]
+ENTRYPOINT ["dockerlint"]
+ENTRYPOINT ["-f", "/Dockerfile"]


### PR DESCRIPTION
### Issue details

When you run dockerlint from inside the docker you can't overwrite the -f unless you want the following error:
```
docker run --rm -v "${PWD}/Dockerfile-base:/Dockerfile-base:ro" -it redcoolbeans/dockerlint
 -p -f /Dockerfile-base 
ERROR: Cannot open /Dockerfile,/Dockerfile-base.
```

Moving the command default arguments to CMD instead of entrypoint is the way to go and it's a best practice, see: https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#entrypoint

And with this patch your output will be:
```
docker run --rm -v "${PWD}/Dockerfile-base:/Dockerfile-base:ro" -it redcoolbeans/dockerlint -p -f /Dockerfile-base

INFO: /Dockerfile-base is OK.
```

The default ones still work with the patch:
```
$ docker run --rm -v "${PWD}/Dockerfile:/Dockerfile:ro" -it redcoolbeans/dockerlint -p
INFO: Dockerfile is OK.

$ docker run --rm -v "${PWD}/Dockerfile:/Dockerfile:ro" -it redcoolbeans/dockerlint

INFO: /Dockerfile is OK.
```

### Steps to reproduce/test case

See above.
