### PR TITLE
Check for trailing spaces in Dockerfile

### DIFF
--- a/src/checks.coffee
+++ b/src/checks.coffee
@@ -32,7 +32,8 @@ exports.all = [
   'onbuild_copyadd',
   'onbuild_disallowed',
   'label_no_empty_value',
-  'variable_use'
+  'variable_use',
+  'no_trailing_spaces'
 ]
 
 # Match $VAR, ${VAR}, and ${VAR:-default}
@@ -370,4 +371,12 @@ exports.variable_use = (rules) ->
         unless exports.variablesDefined(vars, argument) is 'ok'
           utils.log 'ERROR', "#{rule.instruction} contains undefined ARG or ENV variable on line #{rule.line}"
           return 'failed'
+  return 'ok'
+
+# No trailing spaces
+exports.no_trailing_spaces = (rules) ->
+  for rule in rules
+    if rule.raw.endsWith ' '
+      utils.log 'ERROR', 'Lines cannot have trailing spaces'
+      return 'failed'
   return 'ok'

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -40,17 +40,17 @@ exports.parser = (dockerfile) ->
             rule[0].arguments = rule[0].arguments.concat self.getArguments(line)
           else
             cont = true
-            rule.push line: lineno, instruction: self.getInstruction(line), arguments: self.getArguments(line)
+            rule.push raw: line, line: lineno, instruction: self.getInstruction(line), arguments: self.getArguments(line)
         # if current line does not end with \ and cont is true
         # push the saved rule + arguments of current line into `rules`
         # and set `cont` to false and empty `rule`
         else if cont and not line.endsWith '\\'
-          rules.push line: rule[0].line, instruction: rule[0].instruction, arguments: rule[0].arguments.concat self.getArguments(line)
+          rules.push raw: line, line: rule[0].line, instruction: rule[0].instruction, arguments: rule[0].arguments.concat self.getArguments(line)
           rule = []
           cont = false
         # Just save the line, nothing fancy going on now.
         else if not (line.endsWith '\\' and cont)
-          rules.push line: lineno, instruction: self.getInstruction(line), arguments: self.getArguments(line)
+          rules.push raw: line, line: lineno, instruction: self.getInstruction(line), arguments: self.getArguments(line)
 
       lineno++
   rules

--- a/test/checksTest.coffee
+++ b/test/checksTest.coffee
@@ -277,3 +277,7 @@ describe "variable_use", ->
       { line: 3, instruction: 'ENV', arguments: ['EVAR3=$VAR3'] },
     ]
     c.variable_use(r).should.be.equal 'ok'
+
+describe "no_trailing_spaces", ->
+  it "should fail when lines contain trailing spaces", ->
+    c.no_trailing_spaces([ {raw: 'FROM: alpine '}]).should.be.equal 'failed'

--- a/test/parserTest.coffee
+++ b/test/parserTest.coffee
@@ -36,7 +36,7 @@ describe "parser", ->
     p.parser('test/dockerfiles/empty').should.be.deep.equal []
 
   it "should handle comment-only files", ->
-    p.parser('test/dockerfiles/comment_only').should.be.deep.equal [{line: 1, instruction: 'comment', arguments: ['MIT licensed']}]
+    p.parser('test/dockerfiles/comment_only').should.be.deep.equal [{raw: '# MIT licensed', line: 1, instruction: 'comment', arguments: ['MIT licensed']}]
 
   it "should return nothing when handling a non-existent file", ->
     p.parser('test/dockerfiles/nonexistent-file').should.be.deep.equal []
@@ -46,8 +46,8 @@ describe "parser", ->
 
   it "should handle line continuations", ->
     output = [
-      { line: 1, instruction: 'FROM', arguments: [ 'cargos:latest' ] },
-      { line: 3, instruction: 'RUN',  arguments: [ 'yum update &&', 'yum install mg &&', 'yum upgrade' ] },
-      { line: 7, instruction: 'RUN',  arguments: [ 'yum -y update && \\\\ yum -y install tmux' ] }
+      { raw: 'FROM cargos:latest', line: 1, instruction: 'FROM', arguments: [ 'cargos:latest' ] },
+      { raw: '    yum upgrade', line: 3, instruction: 'RUN',  arguments: [ 'yum update &&', 'yum install mg &&', 'yum upgrade' ] },
+      { raw: 'RUN yum -y update && \\\\ yum -y install tmux', line: 7, instruction: 'RUN',  arguments: [ 'yum -y update && \\\\ yum -y install tmux' ] }
     ]
     p.parser('test/dockerfiles/line_continuations').should.be.deep.equal output


### PR DESCRIPTION
### Issue details

`dockerlint` should check for trailing spaces in Dockerfiles

### Steps to reproduce/test case

```Dockerfile
FROM alpine    
RUN echo "The line above is 'FROM alpine    ' and should fail dockerlint"
```
<!--
Please include tests in your pull request, it greatly helps others to
ensure this particular issue won't be re-introduced again.
-->
