### PR TITLE
Update docker.com links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Dockerlint
 
 Linting tool for Dockerfiles based on recommendations from
-[Dockerfile Reference](https://docs.docker.com/reference/builder/) and [Best practices for writing Dockerfiles](https://docs.docker.com/articles/dockerfile_best-practices/) as of Docker 1.6.
+[Dockerfile Reference](https://docs.docker.com/engine/reference/builder/) and [Best practices for writing Dockerfiles](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/) as of Docker 1.6.
 
 ## Install
 


### PR DESCRIPTION
docker.com changed their website - the old links are no longer valid.