### PR TITLE
Ignore command line arguments in variable-check

### DIFF
--- a/src/checks.coffee
+++ b/src/checks.coffee
@@ -101,7 +101,7 @@ exports.mergeVariables = (o, rule, empty) ->
 exports.variablesDefined = (vars, s) ->
   while match = exports.varPattern.exec(s)
     m = match[1] || match[2]
-    unless vars[m]
+    unless vars[m] || isFinite(m) # Command line arguments such as $1, $2... should be ignored
       #utils.log 'DEBUG', "Undefined variable match #{match} within #{s}"
       return 'failed'
   return 'ok'


### PR DESCRIPTION
### Issue details

At the current state, command line arguments such as $1, $2 and so on are marked as undefined environment variables. To avoid this, we check if the name of the variable to check is numeric. Since you can't define environment variables with only digits in its name, this should be sufficient.

### Steps to reproduce/test case

Try to run dockerlint against the Dockerfile of the official redis alpine image (https://github.com/docker-library/redis/blob/master/4.0/alpine/Dockerfile). Without the fix it will find an undefined variable in line 14. Since this is a multi-line-command, the actual problem is located in line 50.