### PR TITLE
Allow multi-stage builds

### DIFF
--- a/test/checksTest.coffee
+++ b/test/checksTest.coffee
@@ -131,12 +131,20 @@ describe "add", ->
 describe "multiple_entries", ->
   for cmd in [ 'CMD', 'ENTRYPOINT' ]
     do (cmd) ->
-      it "should fail when multiple #{cmd} are set", ->
+      it "should fail when multiple #{cmd} are set in the same FROM instruction", ->
         r = [
           { line: 1, instruction: cmd, arguments: ['/sbin/sshd -D'] },
           { line: 2, instruction: cmd, arguments: ['/sbin/sshd -D'] },
         ]
         c.multiple_entries(r).should.be.equal 'failed'
+
+      it "should not fail when multiple #{cmd} are set in different FROM instruction (multi-stage builds)", ->
+        r = [
+          { line: 1, instruction: cmd, arguments: ['/sbin/sshd -D'] },
+          { line: 2, instruction: 'FROM' },
+          { line: 3, instruction: cmd, arguments: ['/sbin/sshd -D'] },
+        ]
+        c.multiple_entries(r).should.be.equal 'ok'
 
 describe "sudo", ->
   it "should warn when sudo is used", ->


### PR DESCRIPTION
### Issue details

Using[ Docker multi-stage builds](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#use-multi-stage-builds) should allow write multiple `CMD`/`ENTRYPOINT` instructions between different `FROM` stages.

### Steps to reproduce/test case

Consider this Dockerfile:
```
FROM node:8.11 AS builder

# ...

FROM builder AS dev

CMD ["nodemon", "app.js"]

FROM builder AS prod

CMD ["pm2", "app.js"]
```
The current version detects the second `CMD` instruction as an error when it is not.