### PR TITLE
Support .tgz extension for the command ADD

### DIFF
--- a/src/checks.coffee
+++ b/src/checks.coffee
@@ -244,12 +244,12 @@ exports.add = (rules) ->
   if add.length > 0
     lines = []
     for rule in add
-      # If the source file is a recognized format (tar, gz, bz, xz), it's allowed
+      # If the source file is a recognized format (tar, gz, bz, xz, tgz), it's allowed
       # usage of ADD. Because image size matters, using ADD to fetch packages from
       # remote URLs is strongly discouraged; you should use curl or wget instead.
       # That way you can delete the files you no longer need after they've been
       # extracted and you won't have to add another layer in your image.
-      lines.push rule.line unless rule.arguments[0].match(/\.(tar|gz|bz2|xz)/)
+      lines.push rule.line unless rule.arguments[0].match(/\.(tar|gz|bz2|xz|tgz)/)
 
     if lines.length > 0
       utils.log exports.pedantic_severity, "ADD instruction used instead of COPY on line #{lines.join ', '}"


### PR DESCRIPTION
### Issue details

**tgz** extension is use to represent  a gzip tar file and is correctly extracted by the docker ADD command.  It should therefore be part of the list of accepted extension

**tgz** extension is used in the wild by python for its source tar file https://www.python.org/ftp/python/3.8.3/Python-3.8.3rc1.tgz


_Please provide issue details here and how your commit(s) fix it_.

### Steps to reproduce/test case

_Please provide necessary steps and relevant parts of your Dockkerfile
below for reproduction of this issue_

    ADD Python-3.8.3rc1.tgz /

<!--
Please include tests in your pull request, it greatly helps others to
ensure this particular issue won't be re-introduced again.
-->
